### PR TITLE
Hackathon817

### DIFF
--- a/veidt/descriptors.py
+++ b/veidt/descriptors.py
@@ -11,6 +11,33 @@ from pymatgen.symmetry.analyzer import SpacegroupAnalyzer
 from veidt.abstract import Describer
 
 
+class Generator(Describer):
+
+    def __init__(self, funcs, labels):
+        """
+        :param funcs [func]: List of functions to map inputs to a
+            single output value.
+        :param labels [str]: List of strings to label the output
+            of each function.
+        """
+        assert len(funcs) == len(labels), \
+            "No. of functions and labels UNEQUAL."
+        self.funcs = funcs
+        self.labels = labels
+
+    def describe(self, obj):
+        """
+        Returns description of an object based on all functions.
+
+        :param obj: Object to be described.
+        :return: {label: value} dict.
+        """
+        output = {}
+        for f, l in zip(self.funcs, self.labels):
+            output[l] = f(obj)
+        return output
+
+
 class DistinctSiteProperty(Describer):
     """
     Constructs a descriptor based on properties of distinct sites in a

--- a/veidt/models.py
+++ b/veidt/models.py
@@ -77,7 +77,7 @@ class LinearModel(Model):
     """
 
     def __init__(self, describer, regressor=LinearRegression()):
-        self.desciber = describer
+        self.describer = describer
         self.model = regressor
 
     def fit(self, inputs, outputs):
@@ -85,11 +85,11 @@ class LinearModel(Model):
         :param inputs: List of inputs
         :param outputs: List of outputs
         """
-        descriptors = self.desciber.describe_all(inputs)
+        descriptors = self.describer.describe_all(inputs)
         self.model.fit(descriptors, outputs)
 
     def predict(self, inputs):
-        descriptors = self.desciber.describe_all(inputs)
+        descriptors = self.describer.describe_all(inputs)
         return self.model.predict(descriptors)
 
     def save(self, model_fname):

--- a/veidt/models.py
+++ b/veidt/models.py
@@ -67,19 +67,22 @@ class NeuralNet(Model):
 
 class LinearModel(Model):
     """
-    Basic linear regression model.
+    Linear model.
 
     :param describer: Desciber object to convert input objects to
         descriptors.
-    :param model: An instance of LinearModel estimator in
-        sklearn.linear_model. Default to LinearRegression(), i.e.,
+    :param regressor (str): Name of LinearModel from
+        sklearn.linear_model. Default to "LinearRegression", i.e.,
         ordinary least squares.
+    :param kwargs: kwargs to be passed to regressor.
     """
-    from sklearn.linear_model import LinearRegression
 
-    def __init__(self, describer, model=LinearRegression()):
+    def __init__(self, describer, regressor="LinearRegression", **kwargs):
+        from sklearn.linear_model import LinearRegression
         self.describer = describer
-        self.model = model
+        self.regressor = regressor
+        self.kwargs = kwargs
+        self.model = eval(regressor)(**kwargs)
 
     def fit(self, inputs, outputs):
         """

--- a/veidt/models.py
+++ b/veidt/models.py
@@ -2,6 +2,8 @@
 # Copyright (c) Materials Virtual Lab
 # Distributed under the terms of the BSD License.
 
+import sys
+
 from veidt.abstract import Model
 
 from sklearn.model_selection import train_test_split
@@ -78,11 +80,13 @@ class LinearModel(Model):
     """
 
     def __init__(self, describer, regressor="LinearRegression", **kwargs):
-        from sklearn.linear_model import LinearRegression
+        import sklearn.linear_model
         self.describer = describer
         self.regressor = regressor
         self.kwargs = kwargs
-        self.model = eval(regressor)(**kwargs)
+        lm = sys.modules["sklearn.linear_model"]
+        lr = getattr(lm, regressor)
+        self.model = lr(**kwargs)
 
     def fit(self, inputs, outputs):
         """

--- a/veidt/models.py
+++ b/veidt/models.py
@@ -76,9 +76,9 @@ class LinearModel(Model):
         sklearn.linear_models.
     """
 
-    def __init__(self, describer, regressor=LinearRegression()):
+    def __init__(self, describer, model=LinearRegression()):
         self.describer = describer
-        self.model = regressor
+        self.model = model
 
     def fit(self, inputs, outputs):
         """

--- a/veidt/models.py
+++ b/veidt/models.py
@@ -72,12 +72,13 @@ class LinearModel(Model):
 
     :param describer: Desciber object to convert input objects to
         descriptors.
-    :param kwargs: Passthrough to sklearn.linear_models.LinearRegression
+    :param regressor: An instance of LinearModel estimator in
+        sklearn.linear_models.
     """
 
-    def __init__(self, describer, **kwargs):
+    def __init__(self, describer, regressor=LinearRegression()):
         self.desciber = describer
-        self.model = LinearRegression(**kwargs)
+        self.model = regressor
 
     def fit(self, inputs, outputs):
         """

--- a/veidt/models.py
+++ b/veidt/models.py
@@ -6,10 +6,6 @@ from veidt.abstract import Model
 
 from sklearn.model_selection import train_test_split
 from sklearn.preprocessing import StandardScaler
-from keras.optimizers import Adam
-from keras.models import Sequential
-from keras.layers import Dense
-from sklearn.linear_model import LinearRegression
 
 
 class NeuralNet(Model):
@@ -40,6 +36,9 @@ class NeuralNet(Model):
         :param test_size: Size of test set. Defaults to 0.2.
         :param kwargs: Passthrough to fit function in keras.models
         """
+        from keras.optimizers import Adam
+        from keras.models import Sequential
+        from keras.layers import Dense
         descriptors = self.desciber.describe_all(inputs)
         scaled_descriptors = self.preprocessor.fit_transform(descriptors)
         adam = Adam(1e-2)
@@ -72,9 +71,11 @@ class LinearModel(Model):
 
     :param describer: Desciber object to convert input objects to
         descriptors.
-    :param regressor: An instance of LinearModel estimator in
-        sklearn.linear_models.
+    :param model: An instance of LinearModel estimator in
+        sklearn.linear_model. Default to LinearRegression(), i.e.,
+        ordinary least squares.
     """
+    from sklearn.linear_model import LinearRegression
 
     def __init__(self, describer, model=LinearRegression()):
         self.describer = describer
@@ -91,6 +92,3 @@ class LinearModel(Model):
     def predict(self, inputs):
         descriptors = self.describer.describe_all(inputs)
         return self.model.predict(descriptors)
-
-    def save(self, model_fname):
-        self.model.save(model_fname)

--- a/veidt/tests/test_descriptors.py
+++ b/veidt/tests/test_descriptors.py
@@ -6,10 +6,36 @@ from __future__ import division, print_function, unicode_literals, \
 import unittest
 import os
 
+import numpy as np
 import pandas as pd
 from pymatgen import Structure
 
-from veidt.descriptors import DistinctSiteProperty
+from veidt.descriptors import Generator, DistinctSiteProperty
+
+
+class GeneratorTest(unittest.TestCase):
+
+    def setUp(self):
+        self.obj = pd.DataFrame(np.random.rand(4, 2), columns=['x', 'y'])
+        self.labels = ["sum", "diff", "prod", "quot"]
+        funcs = []
+        funcs.append(lambda d: d['x'] + d['y'])
+        funcs.append(lambda d: d['x'] - d['y'])
+        funcs.append(lambda d: d['x'] * d['y'])
+        funcs.append(lambda d: d['x'] / d['y'])
+        self.funcs = funcs
+        self.generator = Generator(funcs=funcs, labels=self.labels)
+
+    def test_describe(self):
+        results = self.generator.describe(self.obj)
+        np.testing.assert_array_almost_equal(self.obj['x'] + self.obj['y'],
+                                             results['sum'])
+        np.testing.assert_array_almost_equal(self.obj['x'] - self.obj['y'],
+                                             results['diff'])
+        np.testing.assert_array_almost_equal(self.obj['x'] * self.obj['y'],
+                                             results['prod'])
+        np.testing.assert_array_almost_equal(self.obj['x'] / self.obj['y'],
+                                             results['quot'])
 
 
 class DistinctSitePropertyTest(unittest.TestCase):

--- a/veidt/tests/test_descriptors.py
+++ b/veidt/tests/test_descriptors.py
@@ -5,6 +5,7 @@ from __future__ import division, print_function, unicode_literals, \
 
 import unittest
 import os
+import json
 
 import numpy as np
 import pandas as pd
@@ -15,27 +16,22 @@ from veidt.descriptors import Generator, DistinctSiteProperty
 
 class GeneratorTest(unittest.TestCase):
 
-    def setUp(self):
-        self.obj = pd.DataFrame(np.random.rand(4, 2), columns=['x', 'y'])
-        self.labels = ["sum", "diff", "prod", "quot"]
-        funcs = []
-        funcs.append(lambda d: d['x'] + d['y'])
-        funcs.append(lambda d: d['x'] - d['y'])
-        funcs.append(lambda d: d['x'] * d['y'])
-        funcs.append(lambda d: d['x'] / d['y'])
-        self.funcs = funcs
-        self.generator = Generator(funcs=funcs, labels=self.labels)
+    @classmethod
+    def setUpClass(cls):
+        cls.obj = np.random.rand(10) * 10 - 5
+        cls.func = "lambda x: x + 0.1"
+        func_dict = {"np": "numpy.exp", "lambda": cls.func}
+        cls.generator = Generator(func_dict=func_dict)
 
     def test_describe(self):
         results = self.generator.describe(self.obj)
-        np.testing.assert_array_almost_equal(self.obj['x'] + self.obj['y'],
-                                             results['sum'])
-        np.testing.assert_array_almost_equal(self.obj['x'] - self.obj['y'],
-                                             results['diff'])
-        np.testing.assert_array_almost_equal(self.obj['x'] * self.obj['y'],
-                                             results['prod'])
-        np.testing.assert_array_almost_equal(self.obj['x'] / self.obj['y'],
-                                             results['quot'])
+        np.testing.assert_array_equal(np.exp(self.obj), results["np"])
+        np.testing.assert_array_equal(self.obj + 0.1, results["lambda"])
+
+    def test_serialize(self):
+        json_str = json.dumps(self.generator.as_dict())
+        recover = Generator.from_dict(json.loads(json_str))
+        self.assert_(True)
 
 
 class DistinctSitePropertyTest(unittest.TestCase):

--- a/veidt/tests/test_models.py
+++ b/veidt/tests/test_models.py
@@ -5,8 +5,9 @@ from __future__ import division, print_function, unicode_literals, \
 
 import unittest
 import os
-import numpy as np
+import json
 
+import numpy as np
 from pymatgen import Structure
 
 from veidt.descriptors import DistinctSiteProperty
@@ -48,6 +49,11 @@ class LinearModelTest(unittest.TestCase):
         self.model.fit(inputs=structures, outputs=energies)
         # Given this is a fairly simple model, we should get close to exact.
         self.assertEqual(round(self.model.predict([na2o])[0]), 4, 3)
+
+    def test_serialize(self):
+        json_str = json.dumps(self.model.as_dict())
+        recover = LinearModel.from_dict(json.loads(json_str))
+        self.assert_(True)
 
 if __name__ == "__main__":
     unittest.main()

--- a/veidt/tests/test_models.py
+++ b/veidt/tests/test_models.py
@@ -31,12 +31,11 @@ class NeuralNetTest(unittest.TestCase):
         self.assertEqual(round(self.model.predict([na2o])[0][0]), 4, 3)
 
 
-
 class LinearModelTest(unittest.TestCase):
 
     def setUp(self):
         self.model = LinearModel(
-            describer=DistinctSiteProperty(['8c'], ["Z"]), fit_intercept=True)
+            describer=DistinctSiteProperty(['8c'], ["Z"]))
 
     def test_fit_evaluate(self):
         li2o = Structure.from_file(os.path.join(os.path.dirname(__file__),


### PR DESCRIPTION
# Summary

1. Added `Generator` describer. Only simple functions are supported for now.
2. `veidt.models.LinearModel` now supports any `LinearModel` from `sklearn.linear_model`. Closes #1.
3. Removed `save` method of `LinearModel`. 
4. Separated imports in `models` into different classes to speed up import. 

# TODO
1. Add a format option in `Describer.describe_all`. Basically it will concatenate all the descriptions. Closes #4.
2. Enable nested `lambda` function for `Generator`. 
3. Add methods to save coefficients and intercept for `LinearModel`. 