### PR TITLE
Hackathon817

### DIFF
--- a/veidt/abstract.py
+++ b/veidt/abstract.py
@@ -6,9 +6,13 @@
 Define abstract base classes.
 """
 
-import six
 import abc
+import warnings
+
+import six
 from monty.json import MSONable
+import numpy as np
+import pandas as pd
 
 
 class Describer(six.with_metaclass(abc.ABCMeta, MSONable)):
@@ -41,16 +45,42 @@ class Describer(six.with_metaclass(abc.ABCMeta, MSONable)):
         """
         pass
 
-    def describe_all(self, objs):
+    def describe_all(self, objs, fmt='list'):
         """
         Convenience method to convert a list of objects to a list of
         descriptors. Default implementation simply loops a call to describe, but
         in some instances, a batch implementation may be more efficient.
 
         :param objs: List of objects
-        :return: List of descriptors
+        :param fmt: (Str) output format, Choose among "list" as regular
+            list, "arr" as NumPy array or "df" as pandas DataFrame.
+        :return: Concatenated descriptions for all objects.
         """
-        return [self.describe(o) for o in objs]
+        descriptions = [self.describe(o) for o in objs]
+        concat = None
+        if fmt == 'list':
+            concat = descriptions
+        elif fmt == 'arr':
+            dim = len(np.array(descriptions[0]).shape)
+            if dim > 1:
+                warnings.warn("High dimensional (%d)" % dim +
+                              " data to be concatenated, original index of"
+                              " input list NOT preserved.")
+            concat = np.vstack(descriptions)
+        elif fmt == 'df':
+            if isinstance(descriptions[0], pd.Series):
+                concat = pd.concat(descriptions, axis=1,
+                                   keys=range(len(objs))).T
+            elif isinstance(descriptions[0], pd.DataFrame):
+                concat = pd.concat(descriptions, axis=0,
+                                   keys=range(len(objs)),
+                                   names=["input_index", None])
+        else:
+            raise RuntimeError('Unsupported output format. '
+                               'Choose among "list" as regular list, '
+                               '"arr" as NumPy array or '
+                               '"df" as pandas DataFrame.')
+        return concat
 
 
 class Model(six.with_metaclass(abc.ABCMeta, MSONable)):

--- a/veidt/tests/test_descriptors.py
+++ b/veidt/tests/test_descriptors.py
@@ -18,15 +18,21 @@ class GeneratorTest(unittest.TestCase):
 
     @classmethod
     def setUpClass(cls):
-        cls.obj = np.random.rand(10) * 10 - 5
-        cls.func = "lambda x: x + 0.1"
-        func_dict = {"np": "numpy.exp", "lambda": cls.func}
+        cls.data = np.random.rand(100, 3) * 10 - 5
+        cls.df = pd.DataFrame(cls.data, columns=["x", "y", "z"])
+        func_dict = {"sin": "np.sin",
+                     "sum": "lambda d: d.sum(axis=1)",
+                     "nest": "lambda d: np.log(np.exp(d['x']))"}
         cls.generator = Generator(func_dict=func_dict)
 
     def test_describe(self):
-        results = self.generator.describe(self.obj)
-        np.testing.assert_array_equal(np.exp(self.obj), results["np"])
-        np.testing.assert_array_equal(self.obj + 0.1, results["lambda"])
+        results = self.generator.describe(self.df)
+        np.testing.assert_array_equal(np.sin(self.data),
+                                      results[["sin x", "sin y", "sin z"]])
+        np.testing.assert_array_equal(np.sum(self.data, axis=1),
+                                      results["sum"])
+        np.testing.assert_array_almost_equal(self.data[:, 0],
+                                             results["nest"])
 
     def test_serialize(self):
         json_str = json.dumps(self.generator.as_dict())


### PR DESCRIPTION
#Summary
1. Narrow down the input types for `Generator` to avoid chaos. Closes #2
2. Added a format option for `Describer.describe_all()`. Test to be written. 

