### PR TITLE
Fit feature

### DIFF
--- a/veidt/tests/test_models.py
+++ b/veidt/tests/test_models.py
@@ -44,7 +44,7 @@ class NeuralNetTest(unittest.TestCase):
     def test_model_save_load(self):
         model_fname = os.path.join(self.test_dir, 'test_nnmodel.h5')
         scaler_fname = os.path.join(self.test_dir, 'test_nnscaler.save')
-        self.nn.fit(inputs=self.structures, outputs=self.energies, epochs=100)
+        self.nn.fit(inputs=self.structures, outputs=self.energies, nb_epoch=100)
         self.nn.save(model_fname=model_fname, scaler_fname=scaler_fname)
         self.nn2.load(model_fname=model_fname, scaler_fname=scaler_fname)
         self.assertEqual(self.nn.predict([self.na2o])[0][0], self.nn2.predict([self.na2o])[0][0])


### PR DESCRIPTION
Following today's discussion, i am updating the abstract class. 

Suggested implementations were using a "fit" method to call a "fit_raw" abstract method, where the "fit_raw" abstract method considers the model variation across different ML models. 

I think usually people would think the "fit" method should be the one to implement for different classes. So I changed the naming a little bit, to use a concrete "fit_object" method to call an abstract "fit" method, where the "fit" method implements the model variations. 

Currently, the change of abstract class does not affect the rest of the code (all tests still pass).

This naming could change though. 

I haven't found a way to mandate a `describer` attribute to the abstract class without altering the existing model codes. I am wondering if a mandatory `describer` attribute necessary?