### PR TITLE
Update requirement

### DIFF
--- a/requirements.txt
+++ b/requirements.txt
@@ -9,3 +9,4 @@ scikit-learn==0.20.3
 tensorflow==1.12.2
 six==1.12.0
 h5py==2.9.0
+joblib==0.13.2

--- a/setup.py
+++ b/setup.py
@@ -9,7 +9,7 @@ setup(
     packages=find_packages(),
     version="0.0.2",
     install_requires=["numpy", "scipy", "monty", "keras", "tensorflow",
-                      "scikit-learn", "pandas", "pymatgen", "six", "h5py"],
+                      "scikit-learn", "pandas", "pymatgen", "six", "h5py", "joblib"],
     author="Materials Virtual Lab",
     author_email="ongsp@eng.ucsd.edu",
     maintainer="Shyue Ping Ong",


### PR DESCRIPTION
To fix the py3test job failure. Updated the requirements file and added joblib as a required package. 